### PR TITLE
Add a contains method for iterators

### DIFF
--- a/src/iter.rs
+++ b/src/iter.rs
@@ -1,0 +1,29 @@
+use super::Spec;
+
+use std::cmp::PartialEq;
+use std::fmt::Debug;
+
+pub trait ComparingIterSpec<'s, T: 's>
+    where T: Debug + PartialEq
+{
+    fn contains(self, expected_value: &T);
+}
+
+impl<'s, T: 's, I> ComparingIterSpec<'s, T> for Spec<'s, I>
+    where T: Debug + PartialEq,
+          &'s I: IntoIterator<Item=&'s T>
+{
+    fn contains(self, expected_value: &T) {
+        let mut actual = Vec::new();
+        for x in self.subject {
+            if expected_value.eq(x) {
+                return;
+            } else {
+                actual.push(x);
+            }
+        }
+        self.with_expected(format!("iterator to contain <{:?}>", expected_value))
+            .with_actual(format!("<{:?}>", actual))
+            .fail();
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ pub mod prelude;
 pub mod result;
 pub mod string;
 pub mod vec;
+pub mod iter;
 
 #[derive(Debug)]
 pub struct SpecDescription<'r> {

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -4,3 +4,4 @@ pub use super::option::{OptionSpec, ComparingOptionSpec};
 pub use super::result::ResultSpec;
 pub use super::string::StrSpec;
 pub use super::vec::{VecSpec, ComparingVecSpec};
+pub use super::iter::ComparingIterSpec;

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -21,7 +21,6 @@ impl<'s, T> VecSpec for Spec<'s, Vec<T>> {
 pub trait ComparingVecSpec<'s, T: 's>
     where T: Debug + PartialEq
 {
-    fn contains(self, expected_value: &T);
     fn mapped_contains<F, M: 's>(self, mapping_function: F, expected_value: &M)
         where M: Debug + PartialEq,
               F: Fn(&'s T) -> &M;
@@ -30,13 +29,6 @@ pub trait ComparingVecSpec<'s, T: 's>
 impl<'s, T> ComparingVecSpec<'s, T> for Spec<'s, Vec<T>>
     where T: Debug + PartialEq
 {
-    fn contains(self, expected_value: &T) {
-        let subject = self.subject;
-        if !subject.contains(expected_value) {
-            self.panic_unmatched(expected_value, subject);
-        }
-    }
-
     fn mapped_contains<F, M: 's>(self, mapping_function: F, expected_value: &M)
         where M: Debug + PartialEq,
               F: Fn(&'s T) -> &M

--- a/tests/spectral.rs
+++ b/tests/spectral.rs
@@ -1,6 +1,7 @@
 extern crate spectral;
 
 use spectral::prelude::*;
+use std::collections::LinkedList;
 
 #[test]
 #[should_panic(expected = "test condition: expected <2> but was <1>")]
@@ -92,10 +93,31 @@ fn should_not_panic_if_vec_contains_value() {
 }
 
 #[test]
-#[should_panic(expected = "expected vec to contain <5> but was <[1, 2, 3]>")]
+#[should_panic(expected = "expected iterator to contain <5> but was <[1, 2, 3]>")]
 fn should_panic_if_vec_does_not_contain_value() {
     let test_vec = vec![1,2,3];
     assert_that(&test_vec).contains(&5);
+}
+
+#[test]
+fn should_not_panic_if_iterator_contains_value() {
+    let mut test_into_iter = LinkedList::new();
+    test_into_iter.push_back(1);
+    test_into_iter.push_back(2);
+    test_into_iter.push_back(3);
+
+    assert_that(&test_into_iter).contains(&2);
+}
+
+#[test]
+#[should_panic(expected = "expected iterator to contain <5> but was <[1, 2, 3]>")]
+fn should_panic_if_iterator_does_not_contain_value() {
+    let mut test_into_iter = LinkedList::new();
+    test_into_iter.push_back(1);
+    test_into_iter.push_back(2);
+    test_into_iter.push_back(3);
+
+    assert_that(&test_into_iter).contains(&5);
 }
 
 #[test]


### PR DESCRIPTION
This replaces the contains method for Vec with a more generic
implementation. This version of contains supports anything that
implements IntoIterator.
